### PR TITLE
Fix broken logo and capitalize Beamlens branding

### DIFF
--- a/lib/beamlens_web/components/layouts.ex
+++ b/lib/beamlens_web/components/layouts.ex
@@ -22,7 +22,7 @@ defmodule BeamlensWeb.Layouts do
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="csrf-token" content={Phoenix.Controller.get_csrf_token()} />
-        <title>beamlens</title>
+        <title>Beamlens</title>
         <link rel="icon" type="image/x-icon" href={"#{@asset_prefix}/favicon.ico"} />
         <link rel="icon" type="image/png" sizes="32x32" href={"#{@asset_prefix}/favicon-32.png"} />
         <link rel="icon" type="image/png" sizes="16x16" href={"#{@asset_prefix}/favicon-16.png"} />

--- a/lib/beamlens_web/live/dashboard_live.ex
+++ b/lib/beamlens_web/live/dashboard_live.ex
@@ -41,6 +41,7 @@ defmodule BeamlensWeb.DashboardLive do
 
     {:ok,
      socket
+     |> assign(:asset_prefix, BeamlensWeb.Assets.prefix())
      |> assign(:chat_enabled, chat_enabled)
      |> assign(:selected_source, default_source)
      |> assign(:event_type_filter, nil)
@@ -634,8 +635,8 @@ defmodule BeamlensWeb.DashboardLive do
               <.icon name="hero-bars-3" class="w-5 h-5" />
             </button>
             <a href={@base_path} class="flex items-center gap-2.5 group">
-              <img src="/images/logo/icon-blue.png" alt="beamlens" width="32" height="32" class="w-8 h-8 shrink-0 object-contain transition-transform group-hover:scale-105" />
-              <h1 class="text-lg md:text-xl font-bold text-base-content">beamlens</h1>
+              <img src={"#{@asset_prefix}/images/logo/icon-blue.png"} alt="Beamlens" width="32" height="32" class="w-8 h-8 shrink-0 object-contain transition-transform group-hover:scale-105" />
+              <h1 class="text-lg md:text-xl font-bold text-base-content">Beamlens</h1>
             </a>
           </div>
           <%!-- Desktop header controls --%>


### PR DESCRIPTION
## Summary
- Logo `src` used a hardcoded absolute path (`/images/logo/icon-blue.png`) that bypassed the scoped `_beamlens_web` asset routes — now uses `@asset_prefix` so it loads correctly under any mount scope
- Capitalized "beamlens" → "Beamlens" in the dashboard header and page title

## Test plan
- [x] `mix test` — 90 tests, 0 failures
- [x] Verified logo path now uses the same `@asset_prefix` mechanism as all other assets